### PR TITLE
Remove log4j dependency because of security issues.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ MAINTAINER SURF <edu-beheer@surfnet.nl>
 
 COPY --from=builder /usr/src/app/target/demo-data-server-standalone.jar .
 
+COPY production.logback.xml /
+ENV JDK_JAVA_OPTIONS="-Dlogback.configurationFile=production.logback.xml"
+
 ENV HOST=$HOST
 ENV PORT=$PORT
 ENV SEED=$SEED

--- a/production.logback.xml
+++ b/production.logback.xml
@@ -1,0 +1,27 @@
+<configuration>
+  <!--
+       This is the development logging configuration and won't be on
+       the classpath when running in production.
+
+       For prod or other use cases, set the path to an alternative
+       config using
+
+       java -Dlogback.configurationFile=/path/to/config.xml ...
+
+       See https://logback.qos.ch/manual/configuration.html
+  -->
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="org.eclipse.jetty" level="INFO" />
+  <logger name="org.eclipse.jetty.server" level="WARN" />
+  <logger name="org.eclipse.jetty.util.log" level="WARN" />
+  <root level="info">
+    <appender-ref ref="STDOUT" />
+  </root>
+</configuration>

--- a/project.clj
+++ b/project.clj
@@ -4,13 +4,12 @@
             :url "https://www.gnu.org/licenses/gpl-3.0.en.html"}
   :url "https://github.com/SURFnet/demo-data-ooapi"
   :dependencies [[camel-snake-kebab "0.4.1"]
+                 [ch.qos.logback/logback-classic "1.2.3"]
                  [hiccup "1.0.5"]
-                 [log4j/log4j "1.2.17"]
                  [nl.surf/demo-data "1.0.0"]
                  [nl.zeekat/ring-openapi-validator "0.1.0"]
                  [org.clojure/clojure "1.10.1"]
-                 [org.clojure/tools.logging "0.5.0"]
-                 [org.slf4j/slf4j-log4j12 "1.7.30"]
+                 [org.clojure/tools.logging "1.1.0"]
                  [ring/ring-codec "1.1.2"]
                  [ring/ring-jetty-adapter "1.8.0"]
                  [ring/ring-json "0.5.0"]


### PR DESCRIPTION
Switch to logback. Log4J default configuration has a giant remote code
exection vulnerability.

See also https://www.cert.govt.nz/it-specialists/advisories/log4j-rce-0-day-actively-exploited/